### PR TITLE
feat: Add support default service accounts in roles/editor bindings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: main
+  group: terraform-google-project
   cancel-in-progress: false
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1]
+
+### Added
+
+- Support for provider 4.x
+
 ## [0.1.0]
 
 ### Added
@@ -21,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- markdown-link-check-disable -->
 
-[unreleased]: https://github.com/mineiros-io/terraform-google-project/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/mineiros-io/terraform-google-project/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/mineiros-io/terraform-google-project/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/mineiros-io/terraform-google-project/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/mineiros-io/terraform-google-project/releases/tag/v0.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.1]
+## [0.2.0]
 
 ### Added
 
 - Support for provider 4.x
+- Add support default service accounts in `roles/editor` bindings
+
+### Changed
+
+- upgrade mineiros-io/project-iam/google to v0.1.0
 
 ## [0.1.0]
 
@@ -27,8 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- markdown-link-check-disable -->
 
-[unreleased]: https://github.com/mineiros-io/terraform-google-project/compare/v0.1.1...HEAD
-[0.1.1]: https://github.com/mineiros-io/terraform-google-project/compare/v0.1.0...v0.1.1
+[unreleased]: https://github.com/mineiros-io/terraform-google-project/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/mineiros-io/terraform-google-project/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/mineiros-io/terraform-google-project/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/mineiros-io/terraform-google-project/releases/tag/v0.0.1
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Most basic usage just setting required arguments:
 
 ```hcl
 module "terraform-google-project" {
-  source = "github.com/mineiros-io/terraform-google-project.git?ref=v0.1.0"
+  source = "github.com/mineiros-io/terraform-google-project.git?ref=v0.2.0"
 
   name       = "My Project"
   project_id = "your-project-id"
@@ -121,6 +121,18 @@ See [variables.tf] and [examples/] for details and use-cases.
     Whether to exclusively set (authoritative mode) or add (non-authoritative/additive mode) members to the role.
 
     Default is `true`.
+
+  - **`skip_adding_default_service_accounts`**: _(Optional `bool`)_
+
+    Whether to skip adding default GCP Service Accounts to specific roles.
+
+    Service Accounts added to non-conditional bindings of `roles/editor`:
+
+    - App Engine default service account (`project-id@appspot.gserviceaccount.com`)
+    - Compute Engine default service account (`project-number-compute@developer.gserviceaccount.com`)
+    - Google APIs Service Agent (`project-number@cloudservices.gserviceaccount.com`)
+
+    Default is `false`.
 
 - **`org_id`**: _(Optional `string`)_
 

--- a/iam.tf
+++ b/iam.tf
@@ -11,7 +11,7 @@ locals {
 }
 
 module "iam" {
-  source = "github.com/mineiros-io/terraform-google-project-iam?ref=v0.0.1"
+  source = "github.com/mineiros-io/terraform-google-project-iam?ref=v0.1.0"
 
   for_each = local.iam_map
 
@@ -25,4 +25,6 @@ module "iam" {
   members       = try(each.value.members, [])
   condition     = try(each.value.condition, null)
   authoritative = try(each.value.authoritative, true)
+
+  skip_adding_default_service_accounts = try(each.value.skip_adding_default_service_accounts, false)
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,6 +6,9 @@ terraform {
   required_version = ">= 0.14, < 2.0"
 
   required_providers {
-    google = ">= 3.50, < 4.0"
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.50, < 5.0"
+    }
   }
 }


### PR DESCRIPTION
includes #8

- feat: update google provider to 4.x
- chore: update github test workflow concurrency group
- doc: update CHANGELOG.md
- feat: Add support default service accounts in roles/editor bindings
- chore: prepare 0.2.0 release
